### PR TITLE
Add: 'Payment' generic option to use support PayPal;

### DIFF
--- a/app/scripts/IngresseAPI.js
+++ b/app/scripts/IngresseAPI.js
@@ -955,6 +955,19 @@ angular.module('ingresseSDK')
   };
 
   /**
+   * Get User Wallet (new)
+   */
+  API.getWallet = function () {
+    var deferred = $q.defer();
+
+    API._get('wallet', '', { usertoken: true })
+    .catch(deferred.reject)
+    .then(deferred.resolve);
+
+    return deferred.promise;
+  };
+
+  /**
    * Get PayPal Express Checkout Token
    *
    * @return {Promise}

--- a/app/scripts/constants/PaymentTypeConstant.js
+++ b/app/scripts/constants/PaymentTypeConstant.js
@@ -3,6 +3,6 @@
 angular.module('ingresseSDK')
 .constant('ingressePaymentType', {
   BANKSLIP  : 'BoletoBancario',
-  CREDITCARD: 'CartaoCredito'
+  CREDITCARD: 'CartaoCredito',
 });
 

--- a/app/scripts/services/PaymentService.js
+++ b/app/scripts/services/PaymentService.js
@@ -50,11 +50,16 @@ angular.module('ingresseSDK')
     * @returns {promise}
     */
     Payment.prototype.execute = function () {
-        if (this.transaction.paymentMethod === ingressePaymentType.CREDITCARD) {
-            return this.strategy.creditCardPayment(this.transaction);
-        }
+        switch (this.transaction.paymentMethod) {
+            case ingressePaymentType.CREDITCARD:
+                return this.strategy.creditCardPayment(this.transaction);
 
-        return this.strategy.bankSlipPayment(this.transaction);
+            case ingressePaymentType.BANKSLIP:
+                return this.strategy.bankSlipPayment(this.transaction);
+
+            default:
+                return this.strategy.genericPayment(this.transaction);
+        }
     };
 
     return Payment;

--- a/app/scripts/services/payments/IngresseStrategy.js
+++ b/app/scripts/services/payments/IngresseStrategy.js
@@ -10,6 +10,19 @@ angular.module('ingresseSDK')
     };
 
     /**
+     * Generic Payment Strategy
+     *
+     * @param {object} transaction
+     */
+    var genericPayment = function (transaction) {
+        var deferred = $q.defer();
+
+        deferred.resolve(transaction);
+
+        return deferred.promise;
+    };
+
+    /**
      * Use base strategy prototype
      */
     IngresseStrategy.prototype = new BaseStrategy();
@@ -66,13 +79,14 @@ angular.module('ingresseSDK')
      *
      * @returns {promise}
      */
-    IngresseStrategy.prototype.bankSlipPayment = function (transaction) {
-        var deferred = $q.defer();
+    IngresseStrategy.prototype.bankSlipPayment = genericPayment;
 
-        deferred.resolve(transaction);
-
-        return deferred.promise;
-    };
+    /**
+     * Generic payment
+     *
+     * @returns {promise}
+     */
+    IngresseStrategy.prototype.genericPayment = genericPayment;
 
     return IngresseStrategy;
 });

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ingresse-websdk",
-  "version": "7.30.1",
+  "version": "7.40.0",
   "homepage": "https://github.com/ingresse/ingresse-websdk",
   "authors": [
     "Daniel Borlino de Oliveira <daniel.borlino@ingresse.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingresseemulator",
-  "version": "7.30.1",
+  "version": "7.40.0",
   "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.1",


### PR DESCRIPTION
# Related Issue
- #98 

## Interesting Update
Added `_getUrl` method to `API._get`, `API._post`, `API._delete`, simplifying the `usertoken` as query params;

What we do to search users:

### Currently
```js
  var userToken = '417254-abcdefg...';
  var filters   = {
    term: 'udimberto',
  };

  ingresseAPI.search.getUserTransfer(filters, userToken)
  ...
```

### Now, an alternative
Will automatically get the `userToken` from `IngresseApiUserService` service, without need the consumer application manage the userToken;
```js
  var filters = {
    term: 'udimberto',
  };

  ingresseAPI.search.getUserTransfer(filters, true)
  ...
```
