### PR TITLE
feature: host is setted based on env string

### DIFF
--- a/app/scripts/IngresseAPI.Preferences.js
+++ b/app/scripts/IngresseAPI.Preferences.js
@@ -37,8 +37,8 @@ angular.module('ingresseSDK', [])
       privatekey = key;
     },
     setHost: function (host) {
-      var _host = ('' + (host || 'prod')).toLowerCase();
-      prefHost = (_host.includes('uat')) ? 'https://' + _host + '-api.ingresse.com' : (envs.hasOwnProperty(_host) ? envs[_host] : _host);
+      var envPrefix = host + (host ? '-' : '');
+      prefHost = 'https://' + envPrefix + '-api.ingresse.com';
 
       /* Deprecated */
       if (prefHost === 'https://api.ingresse.com' || prefHost === 'https://apipre.ingresse.com') {
@@ -110,7 +110,9 @@ angular.module('ingresseSDK', [])
         },
         setHost: function (host) {
           this._env  = ('' + (host || 'prod')).toLowerCase();
-          this._host = (this._env.includes('uat')) ? 'https://' + this._env + '-api.ingresse.com' : (envs.hasOwnProperty(this._env) ? envs[this._env] : this._env);
+          
+          var envPrefix = host + (host ? '-' : '');
+          this._host = 'https://' + envPrefix + 'api.ingresse.com';
 
           /* Deprecated */
           if (this._host === 'https://api.ingresse.com' || this._host === 'https://apipre.ingresse.com') {


### PR DESCRIPTION
# Description
Com o objetivo de fazer as aplicações que ainda usar o websdk funcionarem em qualquer ambiente de homologação, independente do nome do ambiente, essa alteração faz com que a string que é recebida como parâmetro na função setHost seja usada par construir a url da api para a qual as requisições serão feitas.